### PR TITLE
implement the creational builder pattern

### DIFF
--- a/covasim/multisim_run_builder.py
+++ b/covasim/multisim_run_builder.py
@@ -1,0 +1,81 @@
+from . import run
+from abc import ABCMeta, abstractmethod
+
+class IBuilder(metaclass=ABCMeta):
+
+    @abstractmethod
+    def run_start(self):
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def build_run(self, reduce=False, combine=False, **kwargs):
+        '''
+        Run the actual sims
+
+        Args:
+            reduce  (bool): whether or not to reduce after running (see reduce())
+            combine (bool): whether or not to combine after running (see combine(), not compatible with reduce)
+            kwargs  (dict): passed to multi_run(); use run_args to pass arguments to sim.run()
+
+        Returns:
+            None (modifies MultiSim object in place)
+
+        **Examples**::
+
+            msim.run()
+            msim.run(run_args=dict(until='2020-0601', restore_pars=False))
+        '''
+        # Handle which sims to use -- same as init_sims()
+        if self.sims is None:
+            sims = self.base_sim
+        else:
+            sims = self.sims
+
+        # Run
+        kwargs = sc.mergedicts(self.run_args, kwargs)
+        self.sims = multi_run(sims, **kwargs)
+
+        # Reduce or combine
+        if reduce:
+            self.reduce()
+        elif combine:
+            self.combine()
+
+        return run
+    
+    @abstractmethod
+    def run_complete(self):
+        pass
+
+
+class Builder(IBuilder):
+    
+    def __init__(self):
+        self.product = Product()
+
+    def run_start(self):
+        self.product.append("Starting to run...")
+
+    def run_complete(self):
+        self.product.append("Run complete.")
+
+    def get_result(self):
+        self.product = self.product.build_run()
+        return self.product
+
+
+class Product():
+
+    def __init__(self):
+        self.parts = []
+
+
+class Director:
+
+    @staticmethod
+    def construct():
+        return IBuilder()\
+        .run_start()\
+        .build_run()\
+        .run_complete()

--- a/covasim/run.py
+++ b/covasim/run.py
@@ -12,6 +12,7 @@ from . import defaults as cvd
 from . import base as cvb
 from . import sim as cvs
 from . import plotting as cvplt
+from . import multisim_run_builder as run
 from .settings import options as cvo
 
 
@@ -140,45 +141,13 @@ class MultiSim(cvb.FlexPretty):
 
 
     def run(self, reduce=False, combine=False, **kwargs):
-        '''
-        Run the actual sims
-
-        Args:
-            reduce  (bool): whether or not to reduce after running (see reduce())
-            combine (bool): whether or not to combine after running (see combine(), not compatible with reduce)
-            kwargs  (dict): passed to multi_run(); use run_args to pass arguments to sim.run()
-
-        Returns:
-            None (modifies MultiSim object in place)
-
-        **Examples**::
-
-            msim.run()
-            msim.run(run_args=dict(until='2020-0601', restore_pars=False))
-        '''
-        # Handle which sims to use -- same as init_sims()
-        if self.sims is None:
-            sims = self.base_sim
-        else:
-            sims = self.sims
-
-        # Run
-        kwargs = sc.mergedicts(self.run_args, kwargs)
-        self.sims = multi_run(sims, **kwargs)
-
-        # Reduce or combine
-        if reduce:
-            self.reduce()
-        elif combine:
-            self.combine()
-
-        return self
+        # returns the result from the builder file
+        return Builder.get_result()
 
 
     def _has_orig_sim(self):
         ''' Helper method for determining if an original base sim is present '''
         return hasattr(self, 'orig_base_sim')
-
 
     def _rm_orig_sim(self, reset=False):
         ''' Helper method for removing the original base sim, if present '''


### PR DESCRIPTION
### Problem
Currently, `run.py` is quite large, making it difficult for developers to understand it at first look. Building an object within this file only adds to the complexity, which goes against coding best practices.

### Solution
A solution to this is to apply the creational design pattern of builder. The builder pattern is the most efficient solution to this problem as it allows the creation of an object that has several working parts, of which each part needs to come together to create one single object.

### How?
I have created the file `multisim_run_builder.py` which creates a run object through using the builder pattern. In this file, I have the `IBuilder` class, which contains the necessary methods for the run object. The `Product` class then creates the object. The `Builder` class then builds the object. And finally, the `Director` class which runs each method. 