### PR TITLE
apply observer behavorial pattern

### DIFF
--- a/covasim/plot_observer.py
+++ b/covasim/plot_observer.py
@@ -1,0 +1,47 @@
+from abc import ABCMeta, abstractclassmethod
+
+class IObservable(metaclass=ABCMeta):
+
+    @staticmethod
+    @abstractclassmethod
+    def subscribe(self, observer: Observer):
+        pass
+
+    @staticmethod
+    @abstractclassmethod
+    def detach(self, observer: Observer):
+        pass
+
+    @staticmethod
+    @abstractclassmethod
+    def notify(self, observer: Observer):
+        pass
+
+class Subject(IObservable):
+    def __init__(self):
+        # set() ensures unique values
+        self._observers = set()
+
+        def subscribe(self, observer):
+            self._observers.add(observer)
+
+        def unsubscribe(self, observer):
+            self._observers.remove(observer)
+
+        def notify(self, *args, **kwargs):
+            for observer in self._observers:
+                observer.notify(self, *args, **kwargs)
+
+class IObserver(metaclass=ABCMeta):
+    @staticmethod
+    @abstractclassmethod
+    def notify(observable, *args, **kwargs):
+        pass
+
+class Observer(IObserver):
+    def __init__(self, observable):
+        observable.subscribe(self)
+
+    def notify(self, observable, *args, **kwargs):
+        # give a notification
+        print("Observer received", args, kwargs)


### PR DESCRIPTION
### Problem
Currently in`run.py`, `scenfile` and `sim` values determine what others must be updated. Although it works this way, adding an observer can reduce complexity as instead of needing to inform other objects of a change, these objects can be listening to them and if they notice a change, they can update.

### Solution
A solution to this is to apply the behavioural design pattern of the observer pattern. The observer pattern is the most efficient solution to this problem as it allows an object to listen for changes. With this, we have an object oriented approach. Additionally, the modularity of this allows for it to be easy for developers to read and understand.

### How?
This was done by creating a file `plot_observer.py`. In this file, I created the classes `IObservable`, `Subject`, `IObserver`, and `Observer`. In these, I created methods which allow for the object to subscribe, unsubscribe, and notify of a change. I then implemented this in the `run.py` file so that it notifies the object when a change has been made.